### PR TITLE
ImportError: cannot import name 'AsyncDDGS' from 'duckduckgo-search'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 openai
 python-dotenv
 colorama
-duckduckgo-search
+duckduckgo-search==6.4.2
 pygments
 rich
 Pillow


### PR DESCRIPTION
`python3 main.py` returns the error below

```
Traceback (most recent call last):
  File "/workspaces/omni-engineer/main.py", line 8, in <module>
    from duckduckgo_search import AsyncDDGS
ImportError: cannot import name 'AsyncDDGS' from 'duckduckgo_search' (/home/vscode/.local/lib/python3.12/site-packages/duckduckgo_search/__init__.py)
```

`AsyncDDGS` was dropped from **duckduckgo-search** package from version `7.0.1`. More info from the GitHub release page [here](https://github.com/deedy5/duckduckgo_search/releases/tag/v7.0.1)

So this my PR is meant close #20 to address the import error by adding the most recent version of **duckduckgo-search** with `AsyncDDGS` module