### PR TITLE
Add devcontainer.json for Daytona development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Omni Engineer",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "secrets": {
+    "OPENAI_API_KEY": {
+      "description": "OpenAI API key"
+    },
+    "ANTHROPIC_API_KEY": {
+      "description": "Anthropic API key"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a `.devcontainer/devcontainer.json` configuration that enables one-click setup in Daytona or VS Code.

The devcontainer:
- Uses Python 3.11 base image
- Auto-installs dependencies from requirements.txt
- Configures VS Code extensions for Python development
- Supports OpenAI and Anthropic API keys as environment secrets

This is created as part of the Daytona Content Bounty #36.