### PR TITLE
Add Daytona devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Omni Engineer",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install -r requirements.txt && cp -n .env.example .env || true",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
+      }
+    }
+  },
+  "remoteEnv": {
+    "PYTHONUNBUFFERED": "1"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,24 @@ Omni Engineer is a spiritual successor to [Claude Engineer](https://github.com/D
    ```
 4. Run the main script:
    ```
-   python omni-eng.py
+   python main.py
+   ```
+
+## Daytona / Dev Container
+
+This repository includes a `.devcontainer/devcontainer.json` for Daytona and
+other Dev Container-compatible tools. The container uses Python 3.11, installs
+`requirements.txt`, and copies `.env.example` to `.env` on first creation so you
+can add your own `OPENROUTER_API_KEY` without committing secrets.
+
+To use it with Daytona:
+
+1. Create a Daytona workspace from this repository.
+2. Open a terminal in the workspace.
+3. Add your OpenRouter key to `.env`.
+4. Run Omni Engineer with:
+   ```
+   python main.py
    ```
 
 ## 📚 Usage


### PR DESCRIPTION
Adds a Dev Container configuration that Daytona can use to create a ready-to-run Omni Engineer workspace.\n\nChanges:\n- Adds .devcontainer/devcontainer.json using Python 3.11.\n- Installs requirements.txt during post-create setup.\n- Copies .env.example to .env if needed so users can add OPENROUTER_API_KEY without committing secrets.\n- Documents the Daytona workflow in README.md.\n\nValidation performed locally:\n- python3 -m json.tool .devcontainer/devcontainer.json\n- git diff --check\n- python3 -m py_compile on repository Python files\n- Fresh venv install: pip install -r requirements.txt