### PR TITLE
Add Daytona devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Omni Engineer",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -r requirements.txt",
+  "containerEnv": {
+    "OPENROUTER_API_KEY": "${localEnv:OPENROUTER_API_KEY}"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a devcontainer configuration for Daytona and other devcontainer-aware environments.
- Install project dependencies after the container is created.

## Why
This gives contributors a reproducible workspace for quickly starting the project and reproducing issues.

## Validation
- `jq empty .devcontainer/devcontainer.json`
- `git diff --check`