### PR TITLE
Add dev container configuration for Daytona / VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"name": "Omni Engineer",
+	"image": "mcr.microsoft.com/devcontainers/python:3.11",
+	"forwardPorts": [],
+	"postCreateCommand": "pip install -r requirements.txt",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"charliermarsh.ruff"
+			]
+		}
+	},
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
## Add a dev container configuration for Daytona / VS Code

This PR adds `.devcontainer/devcontainer.json` so the project can run in a
[dev container](https://containers.dev/) — one-command setup for VS Code Dev
Containers, GitHub Codespaces, and [Daytona](https://www.daytona.io/)
workspaces (`daytona create <repo-url> --code`).

What it includes:

- Python 3.11 base image (`mcr.microsoft.com/devcontainers/python`)
- `postCreateCommand` installing `requirements.txt`
- Recommended VS Code extensions (Python, Pylance, Ruff)
- Non-root `vscode` user

No application code is touched. After merging, users get a fully provisioned
environment with `daytona create https://github.com/Doriandarko/omni-engineer --code`
or by reopening the folder in a dev container.

Part of the Daytona content programme: this dev container is referenced by an
upcoming article about running AI engineers inside Daytona workspaces
(daytonaio/content#36).
